### PR TITLE
Create sram_wrapper_new

### DIFF
--- a/project_files/sram_wrapper_new
+++ b/project_files/sram_wrapper_new
@@ -1,0 +1,55 @@
+//-------------------------instantiates the SRAM
+module sp_ram
+#(parameter ADDR_WIDTH = 11, // 2047 needs 11 bits
+  parameter DATA_WIDTH = 32,
+  parameter NUM_WORDS  = 2048,
+  parameter TOTAL_COUNTER_WIDTH = 15;) // counts (8096*4=2048*16=32768)-1
+( // I/O
+  input  logic                    clk,
+  input  logic                    en_i,
+  input  logic                    we_i,
+  
+  //write operation 
+  input  logic [ADDR_WIDTH-1:0]   addr_i,  // in [10:0] 8 bits can cover 2047 ram WORDS
+  input  logic [DATA_WIDTH-1:0]   wdata_i, // in: [31:0]
+  input  logic [DATA_WIDTH/8-1:0] be_i,     //in: [3:0]
+
+  //read operation
+   output logic [DATA_WIDTH-1:0]   rdata_o, // Out: [31:0]
+   ); 
+//-----------------signal definitions-----------------------------
+logic [ADDR_WIDTH-1:0] addr; 
+assign addr = addr_i;
+
+integer i;
+integer counter [TOTAL_COUNTER_WIDTH]; //11 bits for addresses 4 bits for enables
+//----------------sequential process------------------------------
+    always @(posedge clk) 
+    begin
+    if (en_i && we_i)
+        
+        begin 
+            for (i = 0; i < DATA_WIDTH/8; i++) begin 
+                if(be_i[i]) begin
+                    addr[counter[10:0]] <= wdata[i];
+                    counter++;
+              end
+        end
+
+    rdata_o <= mem[addr];
+    end
+//-----------combinational: break down 32 bits into 4 bytes----
+    genvar w;
+    generate for(w = 0; w < DATA_WIDTH/8; w++) // for(w = 0; w < 4; w++)
+    begin
+        assign wdata[w] = wdata_i[(w+1)*8-1:w*8];
+        // we register data from input here so we have it available next
+        // clock cycles
+                 /* w=0 -> wdata[0] = wdata_i[(7:0]
+                    w=1 -> wdata[1] = wdata_i[(15:8]
+                    w=2 -> wdata[2] = wdata_i[(23:16]
+                    w=3 -> wdata[3] = wdata_i[(31:24]  */
+    end
+    endgenerate
+//----------------------------------------------------------
+endmodule


### PR DESCRIPTION
Hey I have written the wrapper for a single ram but I havent instantiated the corrected RAM yet and havent expanded it to 16 rams yet
One problem is we cannot instantiate the SRAM in the wrapper and have to do it in the CORE file I believe
we need to instantiate 16 rams there and then use 16 wrappers maybe?
or we can just use one wrapper for all 16 and simply tie their enable signal to the wrapper but then we have to write that code in the main CORE file